### PR TITLE
Set Fixed Version for @types/babel-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "zeromq": "^5.1.0"
   },
   "devDependencies": {
+    "@types/babel-types": "7.0.9",
     "@types/node": "^6.0.0",
     "autoprefixer": "^7.1.4",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
@types/babel-types 7.0.9 is the last version that works with typescript 3.4.
The devs released a new version that 4 days ago, that does not work with TS 3.4 anymore.